### PR TITLE
Add linting and test workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+- package-ecosystem: pip
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10
+  allow:
+  - dependency-type: direct
+  - dependency-type: indirect
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Check
+name: Linting
 
 on:
   push:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Black code style
         run: black . --check --target-version py38 --exclude '\.mypy_cache/|\.venv/|env/|(.*/)*snapshots/|.pytype/'
       - name: Docstring formatting
-        run: docformatter -r . --wrap-summaries 88 --wrap-descriptions 88 && docformatter -c -r . --wrap-summaries 88 --wrap-descriptions 88
+        run: docformatter -c -r . --wrap-summaries 88 --wrap-descriptions 88
       - name: Check import order with isort
         run: isort . --check --diff
       - name: PyType type-check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,39 @@
+name: Check
+
+on:
+  push:
+    branches:
+      - main
+  pull_request: {}
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Cancel Outdated Runs
+        uses: styfle/cancel-workflow-action@0.7.0
+        with:
+          access_token: ${{ github.token }}
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip3-${{ hashFiles('*requirements.txt') }}
+      - run: pip install wheel
+      - name: Install dependencies
+        run: pip install -e .[dev]
+      - name: Run Flake8
+        run: flake8
+      - name: Black code style
+        run: black . --check --target-version py38 --exclude '\.mypy_cache/|\.venv/|env/|(.*/)*snapshots/|.pytype/'
+      - name: Docstring formatting
+        run: docformatter -r . --wrap-summaries 88 --wrap-descriptions 88 && docformatter -c -r . --wrap-summaries 88 --wrap-descriptions 88
+      - name: Check import order with isort
+        run: isort . --check --diff
+      - name: PyType type-check
+        run: pytype -j auto .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Unit Tests
+name: Tests
 
 on:
   push:
@@ -30,6 +30,9 @@ jobs:
         run: pip check
       - name: Run unit tests
         run: pytest -vv tests/unit_tests -n auto
+  integration_test:
+    runs-on: ubuntu-latest
+    steps:
       - name: Launch test server
         run: cd tests/integration_tests && docker-compose up -d
       - name: Run integration tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,8 +30,10 @@ jobs:
         run: pip check
       - name: Run unit tests
         run: pytest -vv tests/unit_tests -n auto
+
   integration_test:
     runs-on: ubuntu-latest
+    needs: unit_test
     steps:
       - name: Launch test server
         run: cd tests/integration_tests && docker-compose up -d

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,9 +33,23 @@ jobs:
 
   integration_test:
     runs-on: ubuntu-latest
-    needs: unit_test
     steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip3-${{ hashFiles('*requirements.txt') }}
+      - name: Install dependencies
+        run: pip install -e .[dev]
       - name: Launch test server
-        run: cd tests/integration_tests && docker-compose up -d
+        working-directory: tests/integration_tests
+        run: docker-compose up -d && sleep 10
+      - name: Print docker info
+        run: docker ps -a
       - name: Run integration tests
+        working-directory: tests/integration_tests
         run: pytest . -vv

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,0 +1,36 @@
+name: Unit Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request: {}
+
+jobs:
+  unit_test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Cancel Outdated Runs
+        uses: styfle/cancel-workflow-action@0.7.0
+        with:
+          access_token: ${{ github.token }}
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip3-${{ hashFiles('*requirements.txt') }}
+      - name: Install dependencies
+        run: pip install -e .[dev]
+      - name: Check package version conflicts
+        run: pip check
+      - name: Run unit tests
+        run: pytest -vv tests/unit_tests -n auto
+      - name: Launch test server
+        run: cd tests/integration_tests && docker-compose up -d
+      - name: Run integration tests
+        run: pytest . -vv

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,1 +1,6 @@
+black==20.8b1
+flake8==3.8.4
+isort==5.7.0
 pytest==6.2.1
+pytest-xdist==2.2.0
+pytype==2021.1.28

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 black==20.8b1
+docformatter==1.4
 flake8==3.8.4
 isort==5.7.0
 pytest==6.2.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,42 @@
+[flake8]
+
+# Black compatibility.
+ignore = E203,E501,W503
+exclude = build,dist,env,venv,.env,.venv,.pytype,**/snapshots,ignored
+
+
+[isort]
+
+profile = black
+# Don't misclassify larq as a first-party import.
+known_third_party = larq
+skip =
+    build
+    dist
+    venv
+    .env
+    .venv
+    .git
+    .pytype
+    ignored
+skip_glob = **/snapshots
+
+
+[pytype]
+
+inputs = .
+output = .pytype
+exclude =
+    dist
+    env
+    venv
+    .env
+    .venv
+    .pytype
+    **/snapshots
+    tests
+    **/*_test.py
+    ignored
+# Keep going past errors to analyse as many files as possible.
+keep_going = True
+python_version = 3.8

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 from setuptools import find_packages, setup
 
-install_requires = open("requirements.txt").read().splitlines()
+
+def requires(filename: str):
+    return open(filename).read().splitlines()
+
 
 setup(
     name="snaketalk",
@@ -10,11 +13,12 @@ setup(
     license="MIT",
     description="A simple python bot for Mattermost",
     keywords="chat bot mattermost python",
-    # long_description=open("README.md").read(),
-    # long_description_content_type="text/markdown",
+    long_description=open("README.md").read(),
+    long_description_content_type="text/markdown",
     platforms=["Linux"],
     packages=find_packages(),
-    install_requires=install_requires,
+    install_requires=requires("requirements.txt"),
+    extras_require={"dev": requires("dev-requirements.txt")},
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: MIT License",

--- a/snaketalk/plugins/base.py
+++ b/snaketalk/plugins/base.py
@@ -131,7 +131,7 @@ class Plugin(ABC):
         self, function: Function, message: Message, groups: Sequence[str]
     ):
         if function.is_coroutine:
-            await function(message, *groups)
+            await function(message, *groups)  # type:ignore
         else:
             # By default, we use the global threadpool of the driver, but we could use
             # a plugin-specific thread or process pool if we wanted.

--- a/tests/integration_tests/test_default_plugin.py
+++ b/tests/integration_tests/test_default_plugin.py
@@ -11,7 +11,7 @@ OFF_TOPIC_ID = "8p516nuo8tfpdnhf56geskp7mc"  # Channel id
 def tester():
     return Bot(
         settings=Settings(
-            MATTERMOST_URL="http://localhost",
+            MATTERMOST_URL="http://127.0.0.1",
             BOT_TOKEN="usi1ir74x3yq7qodtzzpc6kudw",
             MATTERMOST_PORT=8065,
             SSL_VERIFY=False,

--- a/tests/integration_tests/test_default_plugin.py
+++ b/tests/integration_tests/test_default_plugin.py
@@ -1,4 +1,5 @@
 import pytest
+
 from snaketalk import Bot, Settings
 
 from .utils import start_bot  # noqa, we only import this so that the bot is started

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -3,6 +3,7 @@ from multiprocessing import Process
 from pathlib import Path
 
 import pytest
+
 from snaketalk import Bot, Message, Plugin, Settings, listen_to
 
 

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -19,7 +19,7 @@ def start_bot(request):
     log_path = Path("./bot.log")
     bot = Bot(
         settings=Settings(
-            MATTERMOST_URL="http://localhost",
+            MATTERMOST_URL="http://127.0.0.1",
             BOT_TOKEN="tdf5ozcwt7yf9kb6xzs748ot1h",
             MATTERMOST_PORT=8065,
             SSL_VERIFY=False,

--- a/tests/unit_tests/bot_test.py
+++ b/tests/unit_tests/bot_test.py
@@ -15,7 +15,7 @@ def bot():
 class TestBot:
     @mock.patch("snaketalk.driver.Driver.login")
     def test_init(self, login):
-        bot = Bot()
+        Bot()
         login.assert_called_once()
 
         # TODO: pass a settings object and verify that the driver was initialized

--- a/tests/unit_tests/message_handler_test.py
+++ b/tests/unit_tests/message_handler_test.py
@@ -1,9 +1,6 @@
-from unittest import mock
-
 import pytest
 
 from snaketalk.message import Message
-from snaketalk.message_handler import MessageHandler
 
 
 @pytest.fixture(scope="function")

--- a/tests/unit_tests/plugins_test.py
+++ b/tests/unit_tests/plugins_test.py
@@ -1,10 +1,3 @@
-from unittest import mock
-
-import pytest
-
-from snaketalk import Function, Plugin, listen_to
-
-
 class TestFunction:
     def test_listen_to(self):
         # TODO: create a Function by using the listen_to decorator, and verify that


### PR DESCRIPTION
Automatically runs a linter, runs the unit tests in parallel with `pytest-xdist`, and runs the integration tests sequentially using the docker image I introduced in #7.

Long-term we probably want to cache the docker image, but I didn't succeed in doing that for now. We can probably create a "fake" dockerfile that simply builds the existing image, and then cache that in a local dir.